### PR TITLE
Add MQTT bounds test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,8 @@ if(NOT CXX_COMPILER_NAME STREQUAL "arm-none-eabi-g++")
     add_custom_target(${EXECUTABLE}
         COMMAND ${CMAKE_COMMAND} -E echo "Error: Unsupported compiler detected(${CXX_COMPILER_NAME}). Use correct compiler(arm-none-eabi-g++) by selecting the CMake kit: Mono_SFCPU"
     )
+    enable_testing()
+    add_subdirectory(tests)
     return()
 endif()
 

--- a/Core/Src/user_mqttFunctions.c
+++ b/Core/Src/user_mqttFunctions.c
@@ -30,7 +30,7 @@ void setMqttTopic(void) {
 }
 
 MqttMessage_t *getMqttMessageByIndex(uint8_t index) {
-  if (index > NUMBER_OF_SENSORS) {
+  if (index >= NUMBER_OF_SENSORS) {
     setSystemError(ERROR_INDEX_OUT_OF_RANGE);
   }
   return &mqttMessages[index];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(unit_tests C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_FLAGS "")
+set(CMAKE_EXE_LINKER_FLAGS "")
+
+add_executable(test_user_mqttFunctions
+    test_user_mqttFunctions.c
+    stub_user_system.c
+    ../Core/Src/user_mqttFunctions.c
+)
+
+target_include_directories(test_user_mqttFunctions BEFORE PRIVATE . ../Core/Inc)
+
+add_test(NAME test_user_mqttFunctions COMMAND test_user_mqttFunctions)

--- a/tests/stub_user_system.c
+++ b/tests/stub_user_system.c
@@ -1,0 +1,11 @@
+#include "user_system.h"
+
+static SystemError currentError = NO_ERROR;
+
+void setSystemError(SystemError error){
+    currentError = error;
+}
+
+SystemError getSystemError(void){
+    return currentError;
+}

--- a/tests/test_user_mqttFunctions.c
+++ b/tests/test_user_mqttFunctions.c
@@ -1,0 +1,9 @@
+#include "user_mqttFunctions.h"
+#include <assert.h>
+
+int main(void) {
+    setSystemError(NO_ERROR);
+    getMqttMessageByIndex(NUMBER_OF_SENSORS);
+    assert(getSystemError() == ERROR_INDEX_OUT_OF_RANGE);
+    return 0;
+}

--- a/tests/user_mqttFunctions.h
+++ b/tests/user_mqttFunctions.h
@@ -1,0 +1,14 @@
+#include "user_system.h"
+
+typedef struct {
+  char topic[MQTT_TOPIC_SIZE];
+  char value[MQTT_MESSAGE_SIZE];
+  // timestamp
+} MqttMessage_t;
+
+void prepareMqttMessageStruct(uint8_t sensorIndex);
+SystemError sendDataToMqttBroker(uint8_t sensorIndex);
+void setMqttTopic(void);
+MqttMessage_t *getMqttMessageByIndex(uint8_t index);
+SystemError sendMqttServer(MqttMessage_t mqttMessage);
+MqttMessage_t *getMqttMessage(void);

--- a/tests/user_system.h
+++ b/tests/user_system.h
@@ -1,0 +1,41 @@
+#ifndef SYSTEM_H
+#define SYSTEM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#define NUMBER_OF_SENSORS 1U
+#define MQTT_TOPIC_SIZE 50U
+#define MQTT_MESSAGE_SIZE 300U
+#define MQTT_SEND_MESSAGE_SIZE (MQTT_TOPIC_SIZE + MQTT_MESSAGE_SIZE)
+#define ADD_AT true
+#define NO_AT false
+
+typedef enum {
+  NO_ERROR,
+  ERROR_MESSAGE_QUEUE,
+  ERROR_FILTER_BUFFER_SIZE,
+  ERROR_INDEX_OUT_OF_RANGE,
+  ERROR_UART_TRANSMIT,
+  ERROR_REPLY,
+  ERROR_NO_AT_REPLY,
+  ERROR_LAST_COMMAND_FAILED,
+  ERROR_SEND_MQTT_FAILED,
+} SystemError;
+
+void setSystemError(SystemError error);
+SystemError getSystemError(void);
+
+/* Inline stubs for unused functions */
+static inline uint16_t getSoilSensorTemperature(void){return 0;}
+static inline uint16_t getSoilSensorMoisture(void){return 0;}
+static inline uint16_t getSoilSensorConductivity(void){return 0;}
+static inline uint16_t getSoilSensorPH(void){return 0;}
+static inline uint16_t getSoilSensorNitrogen(void){return 0;}
+static inline uint16_t getSoilSensorPhosphorus(void){return 0;}
+static inline uint16_t getSoilSensorPotassium(void){return 0;}
+static inline SystemError sendATCommand(char *command, char *param, char *reply, bool addAT){return NO_ERROR;}
+
+#endif /* SYSTEM_H */


### PR DESCRIPTION
## Summary
- set up a minimal test framework
- add failing test for getMqttMessageByIndex out-of-range
- fix bounds check logic
- integrate tests with CMake

## Testing
- `cmake --build . --target test_user_mqttFunctions -- -j 4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6844158e9ef8832da50521bba33426cd